### PR TITLE
Do not pass empty values to the AWS client

### DIFF
--- a/lib/redmine_s3/connection.rb
+++ b/lib/redmine_s3/connection.rb
@@ -29,6 +29,7 @@ module RedmineS3
           :secret_access_key => @@s3_options[:secret_access_key]
         }
         options[:region] = 'ap-northeast-1' if self.region.nil?
+        options.delete_if { |k, v| v.blank? }
 
         @client = Aws::S3::Client.new(options)
       end

--- a/lib/redmine_s3/connection.rb
+++ b/lib/redmine_s3/connection.rb
@@ -24,12 +24,10 @@ module RedmineS3
 
       def establish_connection
         load_options unless @@s3_options[:access_key_id] && @@s3_options[:secret_access_key]
-        options = {
-          :access_key_id => @@s3_options[:access_key_id],
-          :secret_access_key => @@s3_options[:secret_access_key]
-        }
+        options = {}
+        options[:access_key_id] = @@s3_options[:access_key_id] if @@s3_options[:access_key_id].present?
+        options[:access_key_id] = @@s3_options[:secret_access_key] if @@s3_options[:secret_access_key].present?
         options[:region] = 'ap-northeast-1' if self.region.nil?
-        options.delete_if { |k, v| v.blank? }
 
         @client = Aws::S3::Client.new(options)
       end

--- a/lib/redmine_s3/connection.rb
+++ b/lib/redmine_s3/connection.rb
@@ -26,7 +26,7 @@ module RedmineS3
         load_options unless @@s3_options[:access_key_id] && @@s3_options[:secret_access_key]
         options = {}
         options[:access_key_id] = @@s3_options[:access_key_id] if @@s3_options[:access_key_id].present?
-        options[:access_key_id] = @@s3_options[:secret_access_key] if @@s3_options[:secret_access_key].present?
+        options[:secret_access_key] = @@s3_options[:secret_access_key] if @@s3_options[:secret_access_key].present?
         options[:region] = 'ap-northeast-1' if self.region.nil?
 
         @client = Aws::S3::Client.new(options)


### PR DESCRIPTION
The aws-sdk2 client will use the default machine profile if any is setup.
We need to make sure AWS_ACCESS_KEY is not set to an empty string if that's the case.